### PR TITLE
Feature 8 tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ val quarkusPlatformVersion: String by project
 val jaxrsFunctionalTestBuilderVersion: String by project
 val okhttpVersion: String by project
 val jtsVersion: String by project
+val wiremockVersion: String by project
 
 dependencies {
     implementation(enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}"))
@@ -29,6 +30,7 @@ dependencies {
     implementation("io.quarkus:quarkus-undertow")
     implementation("io.quarkus:quarkus-resteasy-reactive")
     implementation("io.quarkus:quarkus-resteasy-reactive-kotlin")
+    implementation("io.quarkus:quarkus-rest-client-reactive-jackson")
     implementation("io.quarkus:quarkus-resteasy-reactive-jackson")
     implementation("io.quarkus:quarkus-oidc")
     implementation("io.quarkus:quarkus-kotlin")
@@ -46,6 +48,7 @@ dependencies {
     }
     implementation("org.jboss.logging:commons-logging-jboss-logging")
 
+    testImplementation("org.wiremock:wiremock:$wiremockVersion")
     testImplementation("io.rest-assured:kotlin-extensions")
     testImplementation("io.rest-assured:rest-assured")
     testImplementation("io.quarkus:quarkus-junit5")
@@ -65,6 +68,7 @@ java {
 
 sourceSets["main"].java {
     srcDir("build/generated/api-spec/src/main/kotlin")
+    srcDir("build/generated/work-planning-api-spec/src/main/kotlin")
 }
 sourceSets["test"].java {
     srcDir("build/generated/api-client/src/main/kotlin")
@@ -123,8 +127,29 @@ val generateApiClient = tasks.register("generateApiClient",GenerateTask::class){
     this.configOptions.put("enumPropertyNaming", "UPPERCASE")
 }
 
+val generateWorkPlanningApiClient = tasks.register("generateWorkPlanningApiClient",GenerateTask::class){
+    setProperty("generatorName", "kotlin-server")
+    setProperty("inputSpec",  "$rootDir/vp-kuljetus-transport-management-specs/services/work-planning-services.yaml")
+    setProperty("outputDir", "$buildDir/generated/work-planning-api-spec")
+    setProperty("apiPackage", "${project.group}.workplanning.spec")
+    setProperty("invokerPackage", "${project.group}.workplanning.invoker")
+    setProperty("modelPackage", "${project.group}.workplanning.model")
+    setProperty("templateDir", "$rootDir/openapi/rest-client")
+    setProperty("validateSpec", false)
+
+    this.configOptions.put("library", "jaxrs-spec")
+    this.configOptions.put("dateLibrary", "java8")
+    this.configOptions.put("enumPropertyNaming", "UPPERCASE")
+    this.configOptions.put("interfaceOnly", "true")
+    this.configOptions.put("useMutiny", "true")
+    this.configOptions.put("returnResponse", "true")
+    this.configOptions.put("useSwaggerAnnotations", "false")
+    this.configOptions.put("additionalModelTypeAnnotations", "@io.quarkus.runtime.annotations.RegisterForReflection")
+}
+
 tasks.named("compileKotlin") {
     dependsOn(generateApiSpec)
+    dependsOn(generateWorkPlanningApiClient)
 }
 
 tasks.named("compileTestKotlin") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,6 +84,11 @@ allOpen {
     annotation("jakarta.persistence.MappedSuperclass")
 }
 
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_17.toString()
+    kotlinOptions.javaParameters = true
+}
+
 tasks.withType<Test> {
     systemProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,4 @@ quarkusPlatformVersion=3.7.1
 jaxrsFunctionalTestBuilderVersion=1.0.6
 okhttpVersion=3.12.13
 jtsVersion=1.19.0
+wiremockVersion=3.3.1

--- a/openapi/rest-client/api.mustache
+++ b/openapi/rest-client/api.mustache
@@ -1,0 +1,31 @@
+package {{package}};
+
+{{#imports}}import {{import}}
+{{/imports}}
+
+import jakarta.ws.rs.*
+import jakarta.ws.rs.core.Response
+
+{{#useSwaggerAnnotations}}
+import io.swagger.annotations.*
+{{/useSwaggerAnnotations}}
+
+import java.io.InputStream
+{{#useBeanValidation}}import jakarta.validation.constraints.*
+import jakarta.validation.Valid{{/useBeanValidation}}
+
+@org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+@org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders
+{{#useSwaggerAnnotations}}
+@Api(description = "the {{{baseName}}} API"){{/useSwaggerAnnotations}}{{#hasConsumes}}
+@Consumes({ {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}} }){{/hasConsumes}}{{#hasProduces}}
+@Produces({ {{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}} }){{/hasProduces}}
+@Path("/")
+{{#interfaceOnly}}interface{{/interfaceOnly}}{{^interfaceOnly}}class{{/interfaceOnly}} {{classname}} {
+{{#operations}}
+{{#operation}}
+
+{{#interfaceOnly}}{{>apiInterface}}{{/interfaceOnly}}{{^interfaceOnly}}{{>apiMethod}}{{/interfaceOnly}}
+{{/operation}}
+}
+{{/operations}}

--- a/src/main/kotlin/fi/metatavu/vp/deliveryinfo/freights/FreightController.kt
+++ b/src/main/kotlin/fi/metatavu/vp/deliveryinfo/freights/FreightController.kt
@@ -1,6 +1,7 @@
 package fi.metatavu.vp.deliveryinfo.freights
 
 import fi.metatavu.vp.deliveryinfo.freights.freightunits.FreightUnitController
+import fi.metatavu.vp.deliveryinfo.tasks.TaskRepository
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import java.util.*
@@ -17,6 +18,9 @@ class FreightController {
     @Inject
     lateinit var freightUnitController: FreightUnitController
 
+    @Inject
+    lateinit var taskRepository: TaskRepository
+
     /**
      * Lists freights
      *
@@ -25,7 +29,7 @@ class FreightController {
      * @return pair of list of freights and total count
      */
     suspend fun list(first: Int?, max: Int?): Pair<List<Freight>, Long> {
-        return freightRepository.listAllSuspending(first, max)
+        return freightRepository.list(first, max)
     }
 
     /**
@@ -94,6 +98,9 @@ class FreightController {
         val freightUnits = freightUnitController.list(freight, null, null)
         freightUnits.first.forEach {
             freightUnitController.delete(it)
+        }
+        taskRepository.list(freight = freight).first.forEach {
+            taskRepository.deleteSuspending(it)
         }
         freightRepository.deleteSuspending(freight)
     }

--- a/src/main/kotlin/fi/metatavu/vp/deliveryinfo/freights/FreightRepository.kt
+++ b/src/main/kotlin/fi/metatavu/vp/deliveryinfo/freights/FreightRepository.kt
@@ -1,6 +1,7 @@
 package fi.metatavu.vp.deliveryinfo.freights
 
 import fi.metatavu.vp.deliveryinfo.persistence.AbstractRepository
+import io.quarkus.panache.common.Sort
 import jakarta.enterprise.context.ApplicationScoped
 import java.util.UUID
 
@@ -55,5 +56,16 @@ class FreightRepository: AbstractRepository<Freight, UUID>() {
         freight.creatorId = creatorId
         freight.lastModifierId = lastModifierId
         return persistSuspending(freight)
+    }
+
+    /**
+     * Lists freights
+     *
+     * @param first first result
+     * @param max max results
+     * @return pair of list of freights and total count
+     */
+    suspend fun list(first: Int?, max: Int?): Pair<List<Freight>, Long> {
+        return applyFirstMaxToQuery(findAll(Sort.descending("modifiedAt")), first, max)
     }
 }

--- a/src/main/kotlin/fi/metatavu/vp/deliveryinfo/rest/AbstractApi.kt
+++ b/src/main/kotlin/fi/metatavu/vp/deliveryinfo/rest/AbstractApi.kt
@@ -207,6 +207,7 @@ abstract class AbstractApi {
         const val SITE = "Site"
         const val FREIGHT = "Freight"
         const val FREIGHT_UNIT = "Freight Unit"
+        const val TASK = "Task"
 
         const val DRIVER_ROLE = "driver"
         const val MANAGER_ROLE = "manager"

--- a/src/main/kotlin/fi/metatavu/vp/deliveryinfo/sites/SiteController.kt
+++ b/src/main/kotlin/fi/metatavu/vp/deliveryinfo/sites/SiteController.kt
@@ -1,5 +1,6 @@
 package fi.metatavu.vp.deliveryinfo.sites
 
+import fi.metatavu.vp.deliveryinfo.tasks.TaskRepository
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import org.locationtech.jts.geom.Geometry
@@ -14,6 +15,9 @@ class SiteController {
 
     @Inject
     lateinit var siteRepository: SiteRepository
+
+    @Inject
+    lateinit var tasksRepository: TaskRepository
 
     private val reader = WKTReader();
 
@@ -39,7 +43,7 @@ class SiteController {
      * @return list of sites
      */
     suspend fun listSites(first: Int?, max: Int?): Pair<List<Site>, Long> {
-        return siteRepository.listAllSuspending(first, max)
+        return siteRepository.list(first, max)
     }
 
     /**
@@ -95,6 +99,9 @@ class SiteController {
      * @param site site
      */
     suspend fun deleteSite(site: Site) {
+        tasksRepository.list(site = site).first.forEach {
+            tasksRepository.deleteSuspending(it)
+        }
         siteRepository.deleteSuspending(site)
     }
 

--- a/src/main/kotlin/fi/metatavu/vp/deliveryinfo/sites/SiteRepository.kt
+++ b/src/main/kotlin/fi/metatavu/vp/deliveryinfo/sites/SiteRepository.kt
@@ -1,6 +1,7 @@
 package fi.metatavu.vp.deliveryinfo.sites
 
 import fi.metatavu.vp.deliveryinfo.persistence.AbstractRepository
+import io.quarkus.panache.common.Sort
 import jakarta.enterprise.context.ApplicationScoped
 import java.util.*
 
@@ -29,6 +30,17 @@ class SiteRepository: AbstractRepository<Site, UUID>() {
         site.creatorId = creatorId
         site.lastModifierId = creatorId
         return persistSuspending(site)
+    }
+
+    /**
+     * Lists sites
+     *
+     * @param first first result
+     * @param max max results
+     * @return list of sites
+     */
+    suspend fun list(first: Int?, max: Int?): Pair<List<Site>, Long> {
+        return applyFirstMaxToQuery(findAll(Sort.descending("modifiedAt")), first, max)
     }
 
 }

--- a/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/Task.kt
+++ b/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/Task.kt
@@ -1,0 +1,39 @@
+package fi.metatavu.vp.deliveryinfo.tasks
+
+import fi.metatavu.vp.api.model.TaskType
+import fi.metatavu.vp.deliveryinfo.freights.Freight
+import fi.metatavu.vp.deliveryinfo.persistence.Metadata
+import fi.metatavu.vp.deliveryinfo.sites.Site
+import jakarta.persistence.*
+import java.util.*
+
+/**
+ * Entity class for Task
+ */
+@Entity
+@Table(name = "task")
+class Task: Metadata() {
+
+    @Id
+    var id: UUID? = null
+
+    @ManyToOne
+    lateinit var freight: Freight
+
+    @ManyToOne
+    lateinit var site: Site
+
+    @Column(nullable=false)
+    @Enumerated(EnumType.STRING)
+    lateinit var type: TaskType
+
+    @Column
+    var remarks: String? = null
+
+    @Column
+    var routeId: UUID? = null
+
+    override lateinit var creatorId: UUID
+
+    override lateinit var lastModifierId: UUID
+}

--- a/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/Task.kt
+++ b/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/Task.kt
@@ -25,7 +25,7 @@ class Task: Metadata() {
 
     @Column(nullable=false)
     @Enumerated(EnumType.STRING)
-    lateinit var type: TaskType
+    lateinit var taskType: TaskType
 
     @Column
     var remarks: String? = null

--- a/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/TaskController.kt
+++ b/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/TaskController.kt
@@ -134,7 +134,7 @@ class TaskController {
     ): Task {
         existingTask.freight = freight
         existingTask.site = site
-        existingTask.type = restTask.type
+        existingTask.taskType = restTask.type
         existingTask.remarks = restTask.remarks
         existingTask.routeId = restTask.routeId
         existingTask.lastModifierId = modifierId

--- a/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/TaskController.kt
+++ b/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/TaskController.kt
@@ -1,0 +1,153 @@
+package fi.metatavu.vp.deliveryinfo.tasks
+
+import fi.metatavu.vp.api.model.TaskType
+import fi.metatavu.vp.deliveryinfo.freights.Freight
+import fi.metatavu.vp.deliveryinfo.sites.Site
+import fi.metatavu.vp.workplanning.spec.RoutesApi
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import java.util.*
+
+/**
+ * Controller for tasks
+ */
+@ApplicationScoped
+class TaskController {
+
+    @Inject
+    lateinit var taskRepository: TaskRepository
+
+    @RestClient
+    lateinit var routesApi: RoutesApi
+
+    @Inject
+    lateinit var logger: org.jboss.logging.Logger
+
+    /**
+     * Checks if route exists
+     *
+     * @param routeId route id
+     * @return true if route exists, false otherwise
+     */
+    suspend fun routeExists(routeId: UUID): Boolean {
+        return try {
+            routesApi.findRoute(routeId).awaitSuspending().status == 200
+        } catch (e: Exception) {
+            logger.error("Error while searching for route $routeId", e)
+            false
+        }
+    }
+
+    /**
+     * Lists tasks
+     *
+     * @param routeId route id
+     * @param assignedToRoute assigned to route
+     * @param freight freight
+     * @param site site
+     * @param type type
+     * @param first first result
+     * @param max max results
+     * @return pair of list of tasks and total count
+     */
+    suspend fun listTasks(
+        routeId: UUID?,
+        assignedToRoute: Boolean?,
+        freight: Freight?,
+        site: Site?,
+        type: TaskType?,
+        first: Int?,
+        max: Int?
+    ): Pair<List<Task>, Long> {
+        return taskRepository.list(
+            routeId = routeId,
+            assignedToRoute = assignedToRoute,
+            freight = freight,
+            site = site,
+            type = type,
+            first = first,
+            max = max
+        )
+    }
+
+    /**
+     * Creates a new task
+     *
+     * @param freight freight
+     * @param site site
+     * @param type type
+     * @param remarks remarks
+     * @param routeId route id
+     * @param creatorId creator id
+     * @param lastModifierId last modifier id
+     * @return created task
+     */
+    suspend fun createTask(
+        freight: Freight,
+        site: Site,
+        type: TaskType,
+        remarks: String?,
+        routeId: UUID?,
+        creatorId: UUID,
+        lastModifierId: UUID
+    ): Task {
+        return taskRepository.create(
+            id = UUID.randomUUID(),
+            freight = freight,
+            site = site,
+            type = type,
+            remarks = remarks,
+            routeId = routeId,
+            creatorId = creatorId,
+            lastModifierId = lastModifierId
+        )
+    }
+
+    /**
+     * Finds a task
+     *
+     * @param taskId task id
+     * @return found task or null if not found
+     */
+    suspend fun findTask(taskId: UUID): Task? {
+        return taskRepository.findByIdSuspending(taskId)
+    }
+
+    /**
+     * Updates a task
+     *
+     * @param existingTask existing task
+     * @param freight freight
+     * @param site site
+     * @param restTask task rest data
+     * @param modifierId modifier id
+     * @return updated task
+     */
+    suspend fun update(
+        existingTask: Task,
+        freight: Freight,
+        site: Site,
+        restTask: fi.metatavu.vp.api.model.Task,
+        modifierId: UUID
+    ): Task {
+        existingTask.freight = freight
+        existingTask.site = site
+        existingTask.type = restTask.type
+        existingTask.remarks = restTask.remarks
+        existingTask.routeId = restTask.routeId
+        existingTask.lastModifierId = modifierId
+        return taskRepository.persistSuspending(existingTask)
+    }
+
+    /**
+     * Deletes a task
+     *
+     * @param foundTask found task
+     */
+    suspend fun deleteTask(foundTask: Task) {
+        taskRepository.deleteSuspending(foundTask)
+    }
+
+}

--- a/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/TaskRepository.kt
+++ b/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/TaskRepository.kt
@@ -41,7 +41,7 @@ class TaskRepository : AbstractRepository<Task, UUID>() {
         task.id = id
         task.freight = freight
         task.site = site
-        task.type = type
+        task.taskType = type
         task.remarks = remarks
         task.routeId = routeId
         task.creatorId = creatorId

--- a/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/TaskRepository.kt
+++ b/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/TaskRepository.kt
@@ -1,0 +1,108 @@
+package fi.metatavu.vp.deliveryinfo.tasks
+
+import fi.metatavu.vp.api.model.TaskType
+import fi.metatavu.vp.deliveryinfo.freights.Freight
+import fi.metatavu.vp.deliveryinfo.persistence.AbstractRepository
+import fi.metatavu.vp.deliveryinfo.sites.Site
+import io.quarkus.panache.common.Parameters
+import jakarta.enterprise.context.ApplicationScoped
+import java.util.*
+
+/**
+ * Repository for Task
+ */
+@ApplicationScoped
+class TaskRepository : AbstractRepository<Task, UUID>() {
+
+    /**
+     * Creates a new task
+     *
+     * @param id id
+     * @param freight freight
+     * @param site site
+     * @param type type
+     * @param remarks remarks
+     * @param routeId route id
+     * @param creatorId creator id
+     * @param lastModifierId last modifier id
+     * @return created task
+     */
+    suspend fun create(
+        id: UUID,
+        freight: Freight,
+        site: Site,
+        type: TaskType,
+        remarks: String?,
+        routeId: UUID?,
+        creatorId: UUID,
+        lastModifierId: UUID
+    ): Task {
+        val task = Task()
+        task.id = id
+        task.freight = freight
+        task.site = site
+        task.type = type
+        task.remarks = remarks
+        task.routeId = routeId
+        task.creatorId = creatorId
+        task.lastModifierId = lastModifierId
+        return persistSuspending(task)
+    }
+
+    /**
+     * Lists tasks
+     *
+     * @param routeId route id
+     * @param assignedToRoute assigned to route
+     * @param freight freight
+     * @param site customer site
+     * @param type type
+     * @param first first result
+     * @param max max results
+     * @return pair of list of tasks and total count
+     */
+    suspend fun list(
+        routeId: UUID? = null,
+        assignedToRoute: Boolean? = null,
+        freight: Freight? = null,
+        site: Site? = null,
+        type: TaskType? = null,
+        first: Int? = null,
+        max: Int? = null
+    ): Pair<List<Task>, Long> {
+        val queryBuilder = StringBuilder()
+        val parameters = Parameters()
+
+        if (routeId != null) {
+            addCondition(queryBuilder, "routeId = :routeId")
+            parameters.and("routeId", routeId)
+        }
+
+        if (assignedToRoute != null) {
+            if (assignedToRoute == true) {
+                addCondition(queryBuilder, "routeId IS NOT NULL")
+            } else {
+                addCondition(queryBuilder, "routeId IS NULL")
+            }
+        }
+
+        if (freight != null) {
+            addCondition(queryBuilder, "freight = :freight")
+            parameters.and("freight", freight)
+        }
+
+        if (site != null) {
+            addCondition(queryBuilder, "site = :site")
+            parameters.and("site", site)
+        }
+
+        if (type != null) {
+            addCondition(queryBuilder, "type = :type")
+            parameters.and("type", type)
+        }
+
+        queryBuilder.append(" order by modifiedAt desc")
+        return applyFirstMaxToQuery(find(queryBuilder.toString(), parameters), first, max)
+    }
+
+}

--- a/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/TaskRepository.kt
+++ b/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/TaskRepository.kt
@@ -97,7 +97,7 @@ class TaskRepository : AbstractRepository<Task, UUID>() {
         }
 
         if (type != null) {
-            addCondition(queryBuilder, "type = :type")
+            addCondition(queryBuilder, "taskType = :type")
             parameters.and("type", type)
         }
 

--- a/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/TaskTranslator.kt
+++ b/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/TaskTranslator.kt
@@ -13,7 +13,7 @@ class TaskTranslator: AbstractTranslator<Task, fi.metatavu.vp.api.model.Task>() 
             id = entity.id,
             freightId = entity.freight.id,
             customerSiteId = entity.site.id!!,
-            type = entity.type,
+            type = entity.taskType,
             remarks = entity.remarks,
             routeId = entity.routeId,
             creatorId = entity.creatorId,

--- a/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/TaskTranslator.kt
+++ b/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/TaskTranslator.kt
@@ -1,0 +1,25 @@
+package fi.metatavu.vp.deliveryinfo.tasks
+
+import fi.metatavu.vp.deliveryinfo.rest.AbstractTranslator
+import jakarta.enterprise.context.ApplicationScoped
+
+/**
+ * Translator for Task JPA to REST entity
+ */
+@ApplicationScoped
+class TaskTranslator: AbstractTranslator<Task, fi.metatavu.vp.api.model.Task>() {
+    override suspend fun translate(entity: Task): fi.metatavu.vp.api.model.Task {
+        return fi.metatavu.vp.api.model.Task(
+            id = entity.id,
+            freightId = entity.freight.id,
+            customerSiteId = entity.site.id!!,
+            type = entity.type,
+            remarks = entity.remarks,
+            routeId = entity.routeId,
+            creatorId = entity.creatorId,
+            lastModifierId = entity.lastModifierId,
+            createdAt = entity.createdAt,
+            modifiedAt = entity.modifiedAt
+        )
+    }
+}

--- a/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/TasksApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/TasksApiImpl.kt
@@ -1,0 +1,166 @@
+package fi.metatavu.vp.deliveryinfo.tasks
+
+import fi.metatavu.vp.api.model.Task
+import fi.metatavu.vp.api.model.TaskType
+import fi.metatavu.vp.api.spec.TasksApi
+import fi.metatavu.vp.deliveryinfo.freights.FreightController
+import fi.metatavu.vp.deliveryinfo.rest.AbstractApi
+import fi.metatavu.vp.deliveryinfo.sites.SiteController
+import io.quarkus.hibernate.reactive.panache.common.WithSession
+import io.quarkus.hibernate.reactive.panache.common.WithTransaction
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.asUni
+import io.vertx.core.Vertx
+import io.vertx.kotlin.coroutines.dispatcher
+import jakarta.annotation.security.RolesAllowed
+import jakarta.enterprise.context.RequestScoped
+import jakarta.inject.Inject
+import jakarta.ws.rs.core.Response
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import java.util.*
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RequestScoped
+@WithSession
+class TasksApiImpl : TasksApi, AbstractApi() {
+
+    @Inject
+    lateinit var taskController: TaskController
+
+    @Inject
+    lateinit var freightController: FreightController
+
+    @Inject
+    lateinit var siteController: SiteController
+
+    @Inject
+    lateinit var taskTranslator: TaskTranslator
+
+    @Inject
+    lateinit var vertx: Vertx
+
+    @RolesAllowed(DRIVER_ROLE, MANAGER_ROLE)
+    override fun listTasks(
+        routeId: UUID?,
+        assignedToRoute: Boolean?,
+        freightId: UUID?,
+        customerSiteId: UUID?,
+        type: TaskType?,
+        first: Int?,
+        max: Int?
+    ): Uni<Response> = CoroutineScope(vertx.dispatcher()).async {
+        val freightFilter = freightId?.let {
+            val foundFreight = freightController.findFreight(it) ?: return@async createNotFound(createNotFoundMessage(FREIGHT, it))
+            foundFreight
+        }
+
+        val siteFilter = customerSiteId?.let {
+            val foundSite = siteController.findSite(it) ?: return@async createNotFound(createNotFoundMessage(SITE, it))
+            foundSite
+        }
+
+        val (tasks, count) = taskController.listTasks(
+            routeId = routeId,
+            assignedToRoute = assignedToRoute,
+            freight = freightFilter,
+            site = siteFilter,
+            type = type,
+            first = first,
+            max = max
+        )
+        createOk(tasks.map { taskTranslator.translate(it) }, count)
+    }.asUni()
+
+    @WithTransaction
+    @RolesAllowed(MANAGER_ROLE)
+    override fun createTask(task: Task): Uni<Response> = CoroutineScope(vertx.dispatcher()).async {
+        val userId = loggedUserId ?: return@async createUnauthorized(UNAUTHORIZED)
+        val freight = task.freightId.let {
+            val foundFreight =
+                freightController.findFreight(it) ?: return@async createBadRequest(createNotFoundMessage(FREIGHT, it))
+            foundFreight
+        }
+        println("freight is valid")
+
+        val site = task.customerSiteId.let {
+            val foundSite = siteController.findSite(it) ?: return@async createBadRequest(createNotFoundMessage(SITE, it))
+            foundSite
+        }
+        println("site is valid")
+
+        if (task.routeId != null && !taskController.routeExists(task.routeId)) {
+            return@async createBadRequest("Bad request")
+        }
+
+        val createdTask = taskController.createTask(
+            freight = freight,
+            site = site,
+            type = task.type,
+            remarks = task.remarks,
+            routeId = task.routeId,
+            creatorId = userId,
+            lastModifierId = userId
+        )
+
+        createOk(taskTranslator.translate(createdTask))
+    }.asUni()
+
+    @RolesAllowed(DRIVER_ROLE, MANAGER_ROLE)
+    override fun findTask(taskId: UUID): Uni<Response> = CoroutineScope(vertx.dispatcher()).async {
+        val task = taskController.findTask(taskId) ?: return@async createNotFound(createNotFoundMessage(TASK, taskId))
+        createOk(taskTranslator.translate(task))
+    }.asUni()
+
+    @WithTransaction
+    @RolesAllowed(MANAGER_ROLE)
+    override fun updateTask(taskId: UUID, task: Task): Uni<Response> = CoroutineScope(vertx.dispatcher()).async {
+        val userId = loggedUserId ?: return@async createUnauthorized(UNAUTHORIZED)
+        val foundTask = taskController.findTask(taskId) ?: return@async createNotFound(createNotFoundMessage(TASK, taskId))
+
+        val freight = task.freightId.let {
+            if (foundTask.freight.id == it) {
+                return@let foundTask.freight
+            }
+            val foundFreight =
+                freightController.findFreight(it) ?: return@async createBadRequest(createNotFoundMessage(FREIGHT, it))
+            foundFreight
+        }
+
+        val site = task.customerSiteId.let {
+            if (foundTask.site.id == it) {
+                return@let foundTask.site
+            }
+            val foundSite =
+                siteController.findSite(it) ?: return@async createBadRequest(createNotFoundMessage(SITE, it))
+            foundSite
+        }
+
+        if (task.routeId != null
+            && foundTask.routeId != task.routeId
+            && !taskController.routeExists(task.routeId)
+        ) {
+            return@async createBadRequest("Bad request")
+        }
+
+        val updated = taskController.update(
+            existingTask = foundTask,
+            freight = freight,
+            site = site,
+            restTask = task,
+            modifierId = userId
+        )
+
+        createOk(taskTranslator.translate(updated))
+    }.asUni()
+
+    @WithTransaction
+    @RolesAllowed(MANAGER_ROLE)
+    override fun deleteTask(taskId: UUID): Uni<Response> = CoroutineScope(vertx.dispatcher()).async {
+        loggedUserId ?: return@async createUnauthorized(UNAUTHORIZED)
+        val foundTask = taskController.findTask(taskId) ?: return@async createNotFound(createNotFoundMessage(TASK, taskId))
+        taskController.deleteTask(foundTask)
+        createNoContent()
+    }.asUni()
+}

--- a/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/TasksApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/TasksApiImpl.kt
@@ -76,6 +76,7 @@ class TasksApiImpl : TasksApi, AbstractApi() {
     @WithTransaction
     @RolesAllowed(MANAGER_ROLE)
     override fun createTask(task: Task): Uni<Response> = CoroutineScope(vertx.dispatcher()).async {
+        println("Creating task ${task.type}")
         val userId = loggedUserId ?: return@async createUnauthorized(UNAUTHORIZED)
         val freight = task.freightId.let {
             val foundFreight =

--- a/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/TasksApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/vp/deliveryinfo/tasks/TasksApiImpl.kt
@@ -82,13 +82,11 @@ class TasksApiImpl : TasksApi, AbstractApi() {
                 freightController.findFreight(it) ?: return@async createBadRequest(createNotFoundMessage(FREIGHT, it))
             foundFreight
         }
-        println("freight is valid")
 
         val site = task.customerSiteId.let {
             val foundSite = siteController.findSite(it) ?: return@async createBadRequest(createNotFoundMessage(SITE, it))
             foundSite
         }
-        println("site is valid")
 
         if (task.routeId != null && !taskController.routeExists(task.routeId)) {
             return@async createBadRequest("Bad request")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,6 +14,9 @@ quarkus.liquibase.validate-on-migrate=true
 # Oidc configuration
 quarkus.oidc.tls.verification=none
 
+# Propagate auth headers to the rest clients
+org.eclipse.microprofile.rest.client.propagateHeaders=Authorization,Proxy-Authorization
+
 # native
 quarkus.native.additional-build-args =\
     -H:ResourceConfigurationFiles=resources-config.json,\

--- a/src/main/resources/db/changeLog.xml
+++ b/src/main/resources/db/changeLog.xml
@@ -101,4 +101,35 @@
             </column>
         </createTable>
     </changeSet>
+
+    <changeSet id="tasks" author="katja danilova">
+        <createTable tableName="task">
+            <column name="id" type="binary(16)">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="freight_id" type="binary(16)">
+                <constraints nullable="false" foreignKeyName="FK_TASK_FREIGHT_ID" referencedColumnNames="id" referencedTableName="freight"/>
+            </column>
+            <column name="site_id" type="binary(16)">
+                <constraints nullable="false" foreignKeyName="FK_TASK_SITE_ID" referencedColumnNames="id" referencedTableName="site"/>
+            </column>
+            <column name="type" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="remarks" type="longtext" />
+            <column name="routeid" type="binary(16)" />
+            <column name="creatorid" type="binary(16)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="createdat" type="datetime(6)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="lastmodifierid" type="binary(16)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="modifiedat" type="datetime(6)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changeLog.xml
+++ b/src/main/resources/db/changeLog.xml
@@ -113,7 +113,7 @@
             <column name="site_id" type="binary(16)">
                 <constraints nullable="false" foreignKeyName="FK_TASK_SITE_ID" referencedColumnNames="id" referencedTableName="site"/>
             </column>
-            <column name="type" type="varchar(255)">
+            <column name="tasktype" type="varchar(191)">
                 <constraints nullable="false"/>
             </column>
             <column name="remarks" type="longtext" />

--- a/src/native-test/kotlin/fi/metatavu/vp/deliveryinfo/functional/NativeTasksTestIT.kt
+++ b/src/native-test/kotlin/fi/metatavu/vp/deliveryinfo/functional/NativeTasksTestIT.kt
@@ -1,0 +1,12 @@
+package fi.metatavu.vp.deliveryinfo.functional
+
+import fi.metatavu.vp.deliveryinfo.functional.impl.WorkPlanningMock
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusIntegrationTest
+
+/**
+ * Native tests for Tasks API
+ */
+@QuarkusIntegrationTest
+@QuarkusTestResource(WorkPlanningMock::class)
+class NativeTasksTestIT: TasksTestIT()

--- a/src/test/kotlin/fi/metatavu/vp/deliveryinfo/functional/TasksTestIT.kt
+++ b/src/test/kotlin/fi/metatavu/vp/deliveryinfo/functional/TasksTestIT.kt
@@ -1,0 +1,313 @@
+package fi.metatavu.vp.deliveryinfo.functional
+
+import fi.metatavu.invalid.InvalidValueTestScenarioBody
+import fi.metatavu.invalid.InvalidValueTestScenarioBuilder
+import fi.metatavu.invalid.InvalidValueTestScenarioPath
+import fi.metatavu.invalid.InvalidValues
+import fi.metatavu.vp.deliveryinfo.functional.impl.InvalidTestValues
+import fi.metatavu.vp.deliveryinfo.functional.impl.WorkPlanningMock
+import fi.metatavu.vp.deliveryinfo.functional.impl.WorkPlanningMock.Companion.routeId
+import fi.metatavu.vp.deliveryinfo.functional.settings.ApiTestSettings
+import fi.metatavu.vp.test.client.models.Task
+import fi.metatavu.vp.test.client.models.TaskType
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.restassured.http.Method
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for Tasks API
+ */
+@QuarkusTest
+@QuarkusTestResource(WorkPlanningMock::class)
+class TasksTestIT : AbstractFunctionalTest() {
+
+    @Test
+    fun testList() = createTestBuilder().use {
+        val site1 = it.manager.sites.create()
+        val freight1 = it.manager.freights.create()
+        val freight2 = it.manager.freights.create()
+        val routeId = WorkPlanningMock.routeId
+        it.manager.tasks.create(
+            customerSiteId = site1.id!!,
+            freightId = freight1.id!!,
+            routeId = null
+        )
+        it.manager.tasks.create(
+            customerSiteId = site1.id,
+            freightId = freight2.id!!,
+            routeId = routeId
+        )
+
+        val totalList = it.manager.tasks.listTasks()
+        assertEquals(2, totalList.size)
+
+        val bytRoute = it.manager.tasks.listTasks(routeId = routeId)
+        assertEquals(1, bytRoute.size)
+
+        val byAssignedToRoute = it.manager.tasks.listTasks(assignedToRoute = true)
+        assertEquals(1, byAssignedToRoute.size)
+
+        val byAssignedToRoute2 = it.manager.tasks.listTasks(assignedToRoute = false)
+        assertEquals(1, byAssignedToRoute2.size)
+
+        val byFreight = it.manager.tasks.listTasks(freightId = freight1.id)
+        assertEquals(1, byFreight.size)
+
+        val bySite = it.manager.tasks.listTasks(customerSiteId = site1.id)
+        assertEquals(2, bySite.size)
+
+        val byType = it.manager.tasks.listTasks(type = TaskType.LOAD)
+        assertEquals(2, byType.size)
+
+        val paging = it.manager.tasks.listTasks(first = 1, max = 1)
+        assertEquals(1, paging.size)
+    }
+
+    @Test
+    fun testListFail() = createTestBuilder().use {
+        it.user.sites.assertListSitesFail(403)
+    }
+
+    @Test
+    fun testCreate() = createTestBuilder().use {
+        val site1 = it.manager.sites.create()
+        val freight1 = it.manager.freights.create()
+        val routeId = WorkPlanningMock.routeId
+        val taskData = Task(
+            freightId = freight1.id!!,
+            customerSiteId = site1.id!!,
+            type = TaskType.LOAD,
+            remarks = "remarks",
+            routeId = routeId
+        )
+
+        val createdTask = it.manager.tasks.create(taskData)
+
+        assertNotNull(createdTask.freightId)
+        assertEquals(taskData.customerSiteId, createdTask.customerSiteId)
+        assertEquals(taskData.type, createdTask.type)
+        assertEquals(taskData.remarks, createdTask.remarks)
+        assertEquals(taskData.freightId, createdTask.freightId)
+        assertEquals(taskData.routeId, createdTask.routeId)
+    }
+
+    @Test
+    fun testCreateFail() = createTestBuilder().use {
+        val site1 = it.manager.sites.create()
+        val freight1 = it.manager.freights.create()
+        val routeId = WorkPlanningMock.routeId
+        val taskData = Task(
+            freightId = freight1.id!!,
+            customerSiteId = site1.id!!,
+            type = TaskType.LOAD,
+            remarks = "remarks",
+            routeId = routeId
+        )
+
+        //Access rights checks
+        it.user.tasks.assertCreateFail(403, taskData)
+        it.driver.tasks.assertCreateFail(403, taskData)
+
+        // Invalid values checks
+        InvalidValueTestScenarioBuilder(
+            path = "v1/tasks",
+            method = Method.POST,
+            token = it.manager.accessTokenProvider.accessToken,
+            basePath = ApiTestSettings.apiBasePath
+        )
+            .body(
+                InvalidValueTestScenarioBody(
+                    values = InvalidTestValues.getInvalidTasks(
+                        validRouteId = routeId,
+                        validFreightId = freight1.id,
+                        validSiteId = site1.id
+                    ),
+                    expectedStatus = 400
+                )
+            )
+            .build()
+            .test()
+    }
+
+    @Test
+    fun testFind() = createTestBuilder().use {
+        val site1 = it.manager.sites.create()
+        val freight1 = it.manager.freights.create()
+        val routeId = WorkPlanningMock.routeId
+        val taskData = Task(
+            freightId = freight1.id!!,
+            customerSiteId = site1.id!!,
+            type = TaskType.LOAD,
+            remarks = "remarks",
+            routeId = routeId
+        )
+
+        val createdTask = it.manager.tasks.create(taskData)
+        val foundTask = it.manager.tasks.findTask(createdTask.id!!)
+
+        assertNotNull(foundTask)
+        assertEquals(createdTask.id, foundTask.id)
+        assertEquals(createdTask.customerSiteId, foundTask.customerSiteId)
+        assertEquals(createdTask.type, foundTask.type)
+        assertEquals(createdTask.remarks, foundTask.remarks)
+        assertEquals(createdTask.freightId, foundTask.freightId)
+        assertEquals(createdTask.routeId, foundTask.routeId)
+    }
+
+    @Test
+    fun testFindFail() = createTestBuilder().use {
+        val site1 = it.manager.sites.create()
+        val freight1 = it.manager.freights.create()
+
+        val createdTask = it.manager.tasks.create(
+            customerSiteId = site1.id!!,
+            freightId = freight1.id!!,
+            routeId = null
+        )
+
+        it.user.tasks.assertFindFail(403, createdTask.id!!)
+
+        InvalidValueTestScenarioBuilder(
+            path = "v1/tasks/{taskId}",
+            method = Method.GET,
+            token = it.manager.accessTokenProvider.accessToken,
+            basePath = ApiTestSettings.apiBasePath
+        )
+            .path(
+                InvalidValueTestScenarioPath(
+                    name = "taskId",
+                    values = InvalidValues.STRING_NOT_NULL,
+                    default = createdTask.id,
+                    expectedStatus = 404
+                )
+            )
+            .build()
+            .test()
+    }
+
+    @Test
+    fun testUpdate() = createTestBuilder().use {
+        val site1 = it.manager.sites.create()
+        val freight1 = it.manager.freights.create()
+
+        val site2 = it.manager.sites.create()
+        val freight2 = it.manager.freights.create()
+
+        val routeId = WorkPlanningMock.routeId
+        val taskData = Task(
+            freightId = freight1.id!!,
+            customerSiteId = site1.id!!,
+            type = TaskType.LOAD,
+            remarks = "remarks",
+            routeId = routeId
+        )
+
+        val createdTask = it.manager.tasks.create(taskData)
+        val updateData = createdTask.copy(
+            freightId = freight2.id!!,
+            customerSiteId = site2.id!!,
+            type = TaskType.UNLOAD,
+            remarks = "remarks2",
+            routeId = null
+        )
+
+        val updated = it.manager.tasks.updateTask(createdTask.id!!, updateData)
+        assertEquals(updateData.freightId, updated.freightId)
+        assertEquals(updateData.customerSiteId, updated.customerSiteId)
+        assertEquals(updateData.type, updated.type)
+        assertEquals(updateData.remarks, updated.remarks)
+        assertEquals(updateData.routeId, updated.routeId)
+    }
+
+    @Test
+    fun testUpdateFail() = createTestBuilder().use {
+        val site1 = it.manager.sites.create()
+        val freight1 = it.manager.freights.create()
+        val createdTask = it.manager.tasks.create(
+            customerSiteId = site1.id!!,
+            freightId = freight1.id!!,
+            routeId = null
+        )
+
+        it.driver.tasks.assertUpdateTaskFail(403, createdTask.id!!, createdTask)
+        it.user.tasks.assertUpdateTaskFail(403, createdTask.id, createdTask)
+
+        // Invalid values checks
+        InvalidValueTestScenarioBuilder(
+            path = "v1/tasks/{taskId}",
+            method = Method.PUT,
+            token = it.manager.accessTokenProvider.accessToken,
+            basePath = ApiTestSettings.apiBasePath
+        )
+            .body(
+                InvalidValueTestScenarioBody(
+                    values = InvalidTestValues.getInvalidTasks(
+                        validRouteId = routeId,
+                        validFreightId = freight1.id,
+                        validSiteId = site1.id
+                    ),
+                    expectedStatus = 400
+                )
+            )
+            .path(
+                InvalidValueTestScenarioPath(
+                    name = "taskId",
+                    values = InvalidValues.STRING_NOT_NULL,
+                    default = createdTask.id,
+                    expectedStatus = 404
+                )
+            )
+            .build()
+            .test()
+    }
+
+    @Test
+    fun testDelete() = createTestBuilder().use {
+        val site1 = it.manager.sites.create()
+        val freight1 = it.manager.freights.create()
+
+        val createdTask = it.manager.tasks.create(
+            customerSiteId = site1.id!!,
+            freightId = freight1.id!!,
+            routeId = null
+        )
+
+        it.manager.tasks.deleteTask(createdTask.id!!)
+        it.manager.tasks.assertFindTaskFail(createdTask.id, 404)
+    }
+
+    @Test
+    fun testDeleteFail() = createTestBuilder().use {
+        val site1 = it.manager.sites.create()
+        val freight1 = it.manager.freights.create()
+
+        val createdTask = it.manager.tasks.create(
+            customerSiteId = site1.id!!,
+            freightId = freight1.id!!,
+            routeId = null
+        )
+
+        it.user.tasks.assertDeleteTaskFail(403, createdTask.id!!)
+        it.driver.tasks.assertDeleteTaskFail(403, createdTask.id)
+
+        InvalidValueTestScenarioBuilder(
+            path = "v1/tasks/{taskId}",
+            method = Method.DELETE,
+            token = it.manager.accessTokenProvider.accessToken,
+            basePath = ApiTestSettings.apiBasePath
+        )
+            .path(
+                InvalidValueTestScenarioPath(
+                    name = "taskId",
+                    values = InvalidValues.STRING_NOT_NULL,
+                    default = createdTask.id,
+                    expectedStatus = 404
+                )
+            )
+            .build()
+            .test()
+    }
+}

--- a/src/test/kotlin/fi/metatavu/vp/deliveryinfo/functional/auth/TestBuilderAuthentication.kt
+++ b/src/test/kotlin/fi/metatavu/vp/deliveryinfo/functional/auth/TestBuilderAuthentication.kt
@@ -7,6 +7,7 @@ import fi.metatavu.vp.deliveryinfo.functional.TestBuilder
 import fi.metatavu.vp.deliveryinfo.functional.impl.FreightTestBuilderResource
 import fi.metatavu.vp.deliveryinfo.functional.impl.FreightUnitTestBuilderResource
 import fi.metatavu.vp.deliveryinfo.functional.impl.SiteTestBuilderResource
+import fi.metatavu.vp.deliveryinfo.functional.impl.TaskTestBuilderResource
 import fi.metatavu.vp.deliveryinfo.functional.settings.ApiTestSettings
 
 /**
@@ -26,6 +27,7 @@ class TestBuilderAuthentication(
     val sites = SiteTestBuilderResource(testBuilder, accessTokenProvider, createClient(accessTokenProvider))
     val freights = FreightTestBuilderResource(testBuilder, accessTokenProvider, createClient(accessTokenProvider))
     val freightUnits = FreightUnitTestBuilderResource(testBuilder, accessTokenProvider, createClient(accessTokenProvider))
+    val tasks = TaskTestBuilderResource(testBuilder, accessTokenProvider, createClient(accessTokenProvider))
 
     override fun createClient(authProvider: AccessTokenProvider): ApiClient {
         val result = ApiClient(ApiTestSettings.apiBasePath)

--- a/src/test/kotlin/fi/metatavu/vp/deliveryinfo/functional/impl/InvalidTestValues.kt
+++ b/src/test/kotlin/fi/metatavu/vp/deliveryinfo/functional/impl/InvalidTestValues.kt
@@ -5,6 +5,8 @@ import fi.metatavu.invalid.InvalidValues
 import fi.metatavu.invalid.providers.SimpleInvalidValueProvider
 import fi.metatavu.vp.test.client.models.FreightUnit
 import fi.metatavu.vp.test.client.models.Site
+import fi.metatavu.vp.test.client.models.Task
+import fi.metatavu.vp.test.client.models.TaskType
 import java.util.*
 
 /**
@@ -30,6 +32,35 @@ class InvalidTestValues: InvalidValues() {
         val INVALID_FREIGHT_UNITS_FREIGHT_ID = listOf(
             FreightUnit(freightId = UUID.randomUUID(), quantityUnit = "pc", type = "type", quantity = "quantity", reservations = "reservations")
         ).map { jacksonObjectMapper().writeValueAsString(it) }.map { SimpleInvalidValueProvider(it) }
+
+        /**
+         * Builds invalid tasks
+         *
+         * @param validRouteId valid route id examples
+         * @param validFreightId valid freight id example
+         * @param validSiteId valid site id example
+         * @return list of invalid body options
+         */
+        fun getInvalidTasks(
+            validRouteId: UUID,
+            validFreightId: UUID,
+            validSiteId: UUID
+        ): List<SimpleInvalidValueProvider> {
+            val sampleValidTask = Task(
+                freightId = validFreightId,
+                customerSiteId = validSiteId,
+                type = TaskType.LOAD,
+                remarks = "remarks",
+                routeId = validRouteId
+            )
+            return listOf(
+                Site(name = "Test site 1", location = "qqq"),
+                sampleValidTask.copy(freightId = UUID.randomUUID()),
+                sampleValidTask.copy(customerSiteId = UUID.randomUUID()),
+                sampleValidTask.copy(routeId = UUID.randomUUID())
+            ).map { jacksonObjectMapper().writeValueAsString(it) }
+                .map { SimpleInvalidValueProvider(it) }
+        }
     }
 
 }

--- a/src/test/kotlin/fi/metatavu/vp/deliveryinfo/functional/impl/TaskTestBuilderResource.kt
+++ b/src/test/kotlin/fi/metatavu/vp/deliveryinfo/functional/impl/TaskTestBuilderResource.kt
@@ -1,0 +1,217 @@
+package fi.metatavu.vp.deliveryinfo.functional.impl
+
+import fi.metatavu.jaxrs.test.functional.builder.auth.AccessTokenProvider
+import fi.metatavu.vp.deliveryinfo.functional.TestBuilder
+import fi.metatavu.vp.deliveryinfo.functional.settings.ApiTestSettings
+import fi.metatavu.vp.test.client.apis.TasksApi
+import fi.metatavu.vp.test.client.infrastructure.ApiClient
+import fi.metatavu.vp.test.client.infrastructure.ClientException
+import fi.metatavu.vp.test.client.models.Task
+import fi.metatavu.vp.test.client.models.TaskType
+import org.junit.Assert
+import java.util.*
+
+/**
+ * Test builder resource for Tasks API
+ */
+class TaskTestBuilderResource(
+    testBuilder: TestBuilder,
+    private val accessTokenProvider: AccessTokenProvider?,
+    apiClient: ApiClient
+) : ApiTestBuilderResource<Task, ApiClient>(testBuilder, apiClient) {
+
+    override fun clean(t: Task) {
+        api.deleteTask(t.id!!)
+    }
+
+    override fun getApi(): TasksApi {
+        ApiClient.accessToken = accessTokenProvider?.accessToken
+        return TasksApi(ApiTestSettings.apiBasePath)
+    }
+
+    /**
+     * Creates new Task
+     *
+     * @param freightId freight id
+     * @param customerSiteId customer site id
+     * @param routeId route id
+     * @return created Task
+     */
+    fun create(
+        freightId: UUID,
+        customerSiteId: UUID,
+        routeId: UUID? = null
+    ): Task {
+        return create(
+            Task(
+                freightId = freightId,
+                customerSiteId = customerSiteId,
+                type = TaskType.LOAD,
+                remarks = "remarks",
+                routeId = routeId
+            )
+        )
+    }
+
+    /**
+     * Creates new Task
+     *
+     * @param task Task data
+     * @return created Task
+     */
+    fun create(task: Task): Task {
+        return addClosable(api.createTask(task))
+    }
+
+    /**
+     * Asserts that Task creation fails with expected status
+     *
+     * @param expectedStatus expected status
+     */
+    fun assertCreateFail(expectedStatus: Int, task: Task) {
+        try {
+            create(task)
+            Assert.fail(String.format("Expected create to fail with status %d", expectedStatus))
+        } catch (ex: ClientException) {
+            assertClientExceptionStatus(expectedStatus, ex)
+        }
+    }
+
+    /**
+     * Finds Task
+     *
+     * @param id id
+     * @return found Task
+     */
+    fun findTask(id: UUID): Task {
+        return api.findTask(id)
+    }
+
+    /**
+     * Asserts that Task find fails with expected status
+     *
+     * @param id id
+     * @param expectedStatus expected status
+     */
+    fun assertFindTaskFail(id: UUID, expectedStatus: Int) {
+        try {
+            findTask(id)
+            Assert.fail(String.format("Expected find to fail with status %d", expectedStatus))
+        } catch (ex: ClientException) {
+            assertClientExceptionStatus(expectedStatus, ex)
+        }
+    }
+
+    /**
+     * Updates Task
+     *
+     * @param id Task id
+     * @param task Task to update
+     * @return updated Task
+     */
+    fun updateTask(id: UUID, task: Task): Task {
+        return api.updateTask(id, task)
+    }
+
+    /**
+     * Asserts that Task update fails with expected status
+     *
+     * @param id task id
+     * @param expectedStatus expected status
+     */
+    fun assertUpdateTaskFail(expectedStatus: Int, id: UUID, taskData: Task) {
+        try {
+            updateTask(id, taskData)
+            Assert.fail(String.format("Expected update to fail with status %d", expectedStatus))
+        } catch (ex: ClientException) {
+            assertClientExceptionStatus(expectedStatus, ex)
+        }
+    }
+
+    /**
+     * Lists tasks
+     *
+     * @param first first result
+     * @param max max results
+     * @return list of tasks
+     */
+    fun listTasks(
+        routeId: UUID? = null,
+        assignedToRoute: Boolean? = null,
+        freightId: UUID? = null,
+        customerSiteId: UUID? = null,
+        type: TaskType? = null,
+        first: Int? = null,
+        max: Int? = null
+    ): Array<Task> {
+        return api.listTasks(
+            routeId = routeId,
+            assignedToRoute = assignedToRoute,
+            freightId = freightId,
+            customerSiteId = customerSiteId,
+            type = type,
+            first = first,
+            max = max
+        )
+    }
+
+    /**
+     * Asserts that task listing fails with expected status
+     *
+     * @param expectedStatus expected status
+     */
+    fun assertListTasksFail(expectedStatus: Int) {
+        try {
+            listTasks()
+            Assert.fail(String.format("Expected list to fail with status %d", expectedStatus))
+        } catch (ex: ClientException) {
+            assertClientExceptionStatus(expectedStatus, ex)
+        }
+    }
+
+    /**
+     * Deletes task
+     *
+     * @param taskId task id
+     */
+    fun deleteTask(taskId: UUID) {
+        api.deleteTask(taskId)
+        removeCloseable { closable: Any ->
+            if (closable !is Task) {
+                return@removeCloseable false
+            }
+
+            closable.id == taskId
+        }
+    }
+
+    /**
+     * Asserts that task deletion fails with expected status
+     *
+     * @param taskId task id
+     * @param expectedStatus expected status
+     */
+    fun assertDeleteTaskFail(expectedStatus: Int, taskId: UUID) {
+        try {
+            deleteTask(taskId)
+            Assert.fail(String.format("Expected delete to fail with status %d", expectedStatus))
+        } catch (ex: ClientException) {
+            assertClientExceptionStatus(expectedStatus, ex)
+        }
+    }
+
+    /**
+     * Asserts that task is found
+     *
+     * @param expected expected
+     * @param actual actual
+     */
+    fun assertFindFail(expectedStatus: Int, taskId: UUID) {
+        try {
+            findTask(taskId)
+            Assert.fail(String.format("Expected find to fail with status %d", expectedStatus))
+        } catch (ex: ClientException) {
+            assertClientExceptionStatus(expectedStatus, ex)
+        }
+    }
+}

--- a/src/test/kotlin/fi/metatavu/vp/deliveryinfo/functional/impl/WorkPlanningMock.kt
+++ b/src/test/kotlin/fi/metatavu/vp/deliveryinfo/functional/impl/WorkPlanningMock.kt
@@ -1,0 +1,74 @@
+package fi.metatavu.vp.deliveryinfo.functional.impl
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.matching.StringValuePattern
+import fi.metatavu.vp.workplanning.model.Route
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import java.time.OffsetDateTime
+import java.util.*
+
+/**
+ * Wiremock for work planning service
+ */
+class WorkPlanningMock : QuarkusTestResourceLifecycleManager {
+    private var wireMockServer: WireMockServer? = null
+
+    private val authHeader = "Authorization"
+    private val bearerPattern: StringValuePattern = WireMock.containing("Bearer")
+
+    private val objectMapper = jacksonObjectMapper().registerModules(JavaTimeModule())
+    override fun start(): Map<String, String> {
+        wireMockServer = WireMockServer(8080)
+        wireMockServer!!.start()
+
+        wireMockServer!!.stubFor(
+            WireMock.get(WireMock.urlPathMatching("/v1/routes/.*"))
+                .withHeader(authHeader, bearerPattern)
+                .willReturn(
+                    WireMock.aResponse()
+                        .withStatus(404)
+                )
+        )
+
+        wireMockServer!!.stubFor(
+            WireMock.get(WireMock.urlEqualTo("/v1/routes/$routeId"))
+                .withHeader(authHeader, bearerPattern)
+                .willReturn(
+                    WireMock.aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(
+                            objectMapper.writeValueAsString(
+                                Route(
+                                    id = routeId,
+                                    vehicleId = vehicleId,
+                                    driverId = driverId,
+                                    departureTime = OffsetDateTime.now(),
+                                    name = "standard route"
+                                )
+                            )
+                        )
+                )
+        )
+
+
+        return java.util.Map.of(
+            "quarkus.rest-client.\"fi.metatavu.vp.workplanning.spec.RoutesApi\".url",
+            wireMockServer!!.baseUrl()
+        )
+    }
+
+    override fun stop() {
+        if (null != wireMockServer) {
+            wireMockServer!!.stop()
+        }
+    }
+
+    companion object {
+        val routeId: UUID = UUID.randomUUID()
+        val vehicleId: UUID = UUID.randomUUID()
+        val driverId: UUID = UUID.randomUUID()
+    }
+}


### PR DESCRIPTION
https://github.com/Metatavu/vp-kuljetus-delivery-info-service-api/issues/8
For now Site/Freight removal triggers deleting the connected tasks, will be changed when the general deletion logic is modified. 
Site/Route/Freight fields are updatable for now. 

Adds env variable to check the routes: 
**quarkus.rest-client."fi.metatavu.vp.workplanning.spec.RoutesApi".url**

Depends on https://github.com/Metatavu/vp-kuljetus-delivery-info-service-api/pull/4